### PR TITLE
handling changed installation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Installing
 
-	cd ~/Library/Application\ Support/Avian/Bundles/
+	cd ~/Library/Application\ Support/TextMate/Bundles/
 	git clone https://github.com/loranger/Laravel.tmbundle.git
 	
 ## Credits


### PR DESCRIPTION
The recent versions of TextMate 2 no longer use "Avian" for its folder within Application Support—at least on my machine.  

If it turns out it's more complicated (like it still uses Avian if you have TextMate 1 installed) then please let me know and I'll try to find a better command for this...
