### PR TITLE
Extra step now required

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 	cd ~/Library/Application\ Support/TextMate/Bundles/
 	git clone https://github.com/loranger/Laravel.tmbundle.git
+	open Laravel.tmbundle
 	
 ## Credits
 


### PR DESCRIPTION
For some reason TextMate now requires you to open the bundle.  Simply restarting TextMate doesn't work, and the old `osascript -e 'tell app "TextMate" to reload bundles'` doesn't work anymore either.   

I assume that opening it in the Finder would also work, but since we're using the Terminal for the rest of the steps, this seems like the most expedient approach.
